### PR TITLE
Mute reason issue#385

### DIFF
--- a/Essentials/src/com/earth2me/essentials/EssentialsPlayerListener.java
+++ b/Essentials/src/com/earth2me/essentials/EssentialsPlayerListener.java
@@ -80,7 +80,14 @@ public class EssentialsPlayerListener implements Listener {
         final User user = ess.getUser(event.getPlayer());
         if (user.isMuted()) {
             event.setCancelled(true);
-            user.sendMessage(tl("voiceSilenced"));
+
+            if (user.getMuteReason ().equals ("")) {
+                user.sendMessage(tl("voiceSilenced"));
+            }
+            else {
+                user.sendMessage(tl("voiceSilenced") + tl("muteFormat", user.getMuteReason ()));
+            }
+
             LOGGER.info(tl("mutedUserSpeaks", user.getName(), event.getMessage()));
         }
         try {

--- a/Essentials/src/com/earth2me/essentials/User.java
+++ b/Essentials/src/com/earth2me/essentials/User.java
@@ -537,6 +537,7 @@ public class User extends UserData implements Comparable<User>, IMessageRecipien
                 setMuteTimeout(0);
                 sendMessage(tl("canTalkAgain"));
                 setMuted(false);
+                setMuteReason ("");
                 return true;
             }
         }

--- a/Essentials/src/com/earth2me/essentials/UserData.java
+++ b/Essentials/src/com/earth2me/essentials/UserData.java
@@ -521,8 +521,12 @@ public abstract class UserData extends PlayerExtension implements IConf {
     }
 
     public void setMuteReason (String reason) {
-        muteReason = reason;
-        config.setProperty ("muteReason", reason);
+        if (reason.equals("")) {
+            config.removeProperty ("muteReason");
+        } else {
+            muteReason = reason;
+            config.setProperty ("muteReason", reason);
+        }
         config.save();
     }
 

--- a/Essentials/src/com/earth2me/essentials/UserData.java
+++ b/Essentials/src/com/earth2me/essentials/UserData.java
@@ -73,6 +73,7 @@ public abstract class UserData extends PlayerExtension implements IConf {
         godmode = _getGodModeEnabled();
         muted = _getMuted();
         muteTimeout = _getMuteTimeout();
+        muteReason = _getMuteReason ();
         jailed = _getJailed();
         jailTimeout = _getJailTimeout();
         lastLogin = _getLastLogin();
@@ -491,6 +492,7 @@ public abstract class UserData extends PlayerExtension implements IConf {
     }
 
     private boolean muted;
+    private String muteReason;
 
     public boolean _getMuted() {
         return config.getBoolean("muted", false);
@@ -507,6 +509,20 @@ public abstract class UserData extends PlayerExtension implements IConf {
     public void setMuted(boolean set) {
         muted = set;
         config.setProperty("muted", set);
+        config.save();
+    }
+
+    public String _getMuteReason() {
+        return config.getString("muteReason");
+    }
+
+    public String getMuteReason() {
+        return muteReason;
+    }
+
+    public void setMuteReason (String reason) {
+        muteReason = reason;
+        config.setProperty ("muteReason", reason);
         config.save();
     }
 

--- a/Essentials/src/com/earth2me/essentials/commands/Commandmute.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandmute.java
@@ -52,7 +52,9 @@ public class Commandmute extends EssentialsCommand {
             if (args.length > 1) {
                 final String time = getFinalArg(args, 1);
                 muteTimestamp = DateUtil.parseDateDiff(time, true);
+                String muteReason = DateUtil.removeTimePattern (time);
                 user.setMuted(true);
+                user.setMuteReason (muteReason);
             } else {
                 user.setMuted(!user.getMuted());
             }
@@ -70,6 +72,7 @@ public class Commandmute extends EssentialsCommand {
                     user.sendMessage(tl("playerMutedFor", muteTime));
                 } else {
                     sender.sendMessage(tl("mutedPlayer", user.getDisplayName()));
+                    /** Send the player a message, why they were muted **/
                     user.sendMessage(tl("playerMuted"));
                 }
                 final String message;

--- a/Essentials/src/messages.properties
+++ b/Essentials/src/messages.properties
@@ -494,6 +494,7 @@ vanished=\u00a76You are now completely invisible to normal users, and hidden fro
 versionMismatch=\u00a74Version mismatch\! Please update {0} to the same version.
 versionMismatchAll=\u00a74Version mismatch\! Please update all Essentials jars to the same version.
 voiceSilenced=\u00a76Your voice has been silenced\!
+muteFormat=\u00a74 Reason: {0}
 walking=walking
 warpDeleteError=\u00a74Problem deleting the warp file.
 warpList={0}


### PR DESCRIPTION
Added the ability for adding in a reason to the muting feature. This will allow the muter to add a reason and whenever the user that is muted speaks, the muteReason will be displayed along with the "you have been silenced" message. Currently it is not fully implemented.