### PR TITLE
Mute reason issue#385 [Handling mute without timeframe]

### DIFF
--- a/Essentials/src/com/earth2me/essentials/UserData.java
+++ b/Essentials/src/com/earth2me/essentials/UserData.java
@@ -517,12 +517,18 @@ public abstract class UserData extends PlayerExtension implements IConf {
     }
 
     public String getMuteReason() {
-        return muteReason;
+        if (muteReason != null) {
+            return muteReason;
+        }
+        else {
+            return "";
+        }
     }
 
     public void setMuteReason (String reason) {
         if (reason.equals("")) {
             config.removeProperty ("muteReason");
+            muteReason = null;
         } else {
             muteReason = reason;
             config.setProperty ("muteReason", reason);

--- a/Essentials/src/com/earth2me/essentials/commands/Commandmute.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandmute.java
@@ -52,11 +52,12 @@ public class Commandmute extends EssentialsCommand {
             if (args.length > 1) {
                 final String time = getFinalArg(args, 1);
                 muteTimestamp = DateUtil.parseDateDiff(time, true);
-                String muteReason = "";
+                String muteReason;
+                
                 try {
                     muteReason = DateUtil.removeTimePattern (time);
                 } catch (Exception e) {
-                    user.setMuteReason (muteReason);
+                    muteReason = time;
                 }
 
                 user.setMuteReason (muteReason);

--- a/Essentials/src/com/earth2me/essentials/commands/Commandmute.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandmute.java
@@ -52,9 +52,15 @@ public class Commandmute extends EssentialsCommand {
             if (args.length > 1) {
                 final String time = getFinalArg(args, 1);
                 muteTimestamp = DateUtil.parseDateDiff(time, true);
-                String muteReason = DateUtil.removeTimePattern (time);
-                user.setMuted(true);
+                String muteReason = "";
+                try {
+                    muteReason = DateUtil.removeTimePattern (time);
+                } catch (Exception e) {
+                    user.setMuteReason (muteReason);
+                }
+
                 user.setMuteReason (muteReason);
+                user.setMuted(true);
             } else {
                 user.setMuted(!user.getMuted());
             }


### PR DESCRIPTION
This should be a workable way to handle the mutes without a time frame, Essentially we are catching an exception if there is no time frame on the mute command and then processing the string as is. So if someone issues the command `/mute CreedTheFreak Because I said so` the lack of the numerical time stamp will allow us to process the ban reason without exiting the command or giving an error since the absence of a numerical time stamp can also be used.